### PR TITLE
Tests are invalid without at least one `function test*()`.

### DIFF
--- a/tests/src/Unit/LeftPadTest.php
+++ b/tests/src/Unit/LeftPadTest.php
@@ -22,7 +22,7 @@ class LeftPadTest extends UnitTestCase {
   /**
    * Tests that strings with less than 6 characters are padded to 6 characters.
    */
-  public function LessThanSixCharactersTest() {
+  public function testLessThanSixCharacters() {
     $this->assertRegExp(
       '/^\d{6}$/',
       interswitch_donate_left_pad_transaction_id('123')


### PR DESCRIPTION
Without any test methods that PHPUnit can find, it will strip the class from the test list, affecting --list-groups.
